### PR TITLE
index.tsx, app.tsx, enable more rules

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import React from 'react';
 import App from './App';
 
 test('renders learn react link', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-// import KBBoard from './components/KB/KBBoard'
-import KBClass from './components/KB/KBClass.tsx'
+import React from 'react';
+import KBClass from './components/KB/KBClass'
 import './App.css';
 
 function App() {

--- a/src/components/KB/KBClass.tsx
+++ b/src/components/KB/KBClass.tsx
@@ -1,8 +1,6 @@
 import React, { Component } from "react";
-// @ts-ignore
-import BoardInput from "../BoardInput/BoardInput.tsx"
-// @ts-ignore
-import Stage from "../Stage/Stage.tsx"
+import BoardInput from "../BoardInput/BoardInput"
+import Stage from "../Stage/Stage"
 // @ts-ignore
 import { Task } from "../types";
 import "./KBBoard.css";

--- a/src/components/Stage/Stage.tsx
+++ b/src/components/Stage/Stage.tsx
@@ -1,7 +1,5 @@
 import React from "react";
-// @ts-ignore
-import TaskCard from "../TaskCard/TaskCard.tsx"
-// @ts-ignore
+import TaskCard from "../TaskCard/TaskCard"
 import "./Stage.css"
 
 interface StageProps {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
-import reportWebVitals from './reportWebVitals';
+//import reportWebVitals from './reportWebVitals';
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
     <App />
@@ -14,4 +14,4 @@ root.render(
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+//reportWebVitals();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -76,14 +76,14 @@
 
     /* Type Checking */
     "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
-    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+    "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+    "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
     // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */


### PR DESCRIPTION
error on line 7 of index.tsx: Argument of type 'HTMLElement | null' is not assignable to parameter of type 'Element'. Type 'null' is not assignable to type 'Element'.ts(2345) fixed by adding 'as HTMLElement' alternatively could add ! operator because it will not be null